### PR TITLE
remove +1 to root_path to keep metric's first character

### DIFF
--- a/carbonate/list.py
+++ b/carbonate/list.py
@@ -23,7 +23,7 @@ def main():
         for root, dirnames, filenames in os.walk(args.storage_dir):
             for filename in filenames:
                 if metric_regex.match(filename):
-                    root_path = root[len(args.storage_dir) + 1:]
+                    root_path = root[len(args.storage_dir):]
                     m_path = os.path.join(root_path, filename)
                     m_name, m_ext = os.path.splitext(m_path)
                     m_name = m_name.replace('/', '.')


### PR DESCRIPTION
On my setup, carbon-list prints out metrics without the first character like that:
arbon.relays.graph-01-1.memUsage
arbon.relays.graph-01-1.cpuUsage

I don't understand why you added this +1 so I assume it's a bug.
