### PR TITLE
Changed time.time to just plain time, since we're importing time from time

### DIFF
--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -251,6 +251,6 @@ def whisper_fill():
     src = args.source
     dst = args.dest
 
-    startFrom = time.time()
+    startFrom = time()
 
     fill_archives(src, dst, startFrom)


### PR DESCRIPTION
Hi! This is a great set of tools; thanks for writing it. When I tried to use whisper-fill I got this error:

Traceback (most recent call last):
  File "/Users/bridget/carbonate/bin/whisper-fill", line 9, in <module>
    load_entry_point('carbonate==0.2.0', 'console_scripts', 'whisper-fill')()
  File "build/bdist.macosx-10.8-intel/egg/carbonate/cli.py", line 254, in whisper_fill
AttributeError: 'builtin_function_or_method' object has no attribute 'time'

This appears to be happening because of the "from time import time" line at the top. Doubtless this changed along the way, so now it appears we no longer need time.time() - just plain time() works for me without error.

Hope this change helps someone else!
