### PR TITLE
Handle aggregation input that cannot be split without dying

### DIFF
--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -243,13 +243,16 @@ def whisper_aggregate():
     metrics_count = 0
 
     for metric in metrics:
-        name, t = metric.strip().split('|')
+        try:
+            name, t = metric.strip().split('|')
 
-        mode = AGGREGATION[t]
-        if mode is not None:
-            cname = name.replace('.', '/')
-            path = os.path.join(args.storage_dir, cname + '.wsp')
-            metrics_count = metrics_count + setAggregation(path, mode)
+            mode = AGGREGATION[t]
+            if mode is not None:
+                cname = name.replace('.', '/')
+                path = os.path.join(args.storage_dir, cname + '.wsp')
+                metrics_count = metrics_count + setAggregation(path, mode)
+        except ValueError, exc:
+            logging.warning("Unable to parse '%s' (%s)" % (metric, str(exc)))
 
     logging.info('Successfully set aggregation mode for ' +
                  '%d of %d metrics' % (metrics_count, len(metrics)))


### PR DESCRIPTION
Improperly formatted aggregation dump data can cause whisper-aggregate to die on a ValueError thrown by split().

```
Traceback (most recent call last):
  File "/usr/bin/whisper-aggregate", line 9, in <module>
    load_entry_point('carbonate==0.2.1', 'console_scripts', 'whisper-aggregate')()
  File "/usr/lib/python2.7/dist-packages/carbonate/cli.py", line 321, in whisper_aggregate
    name, t = metric.strip().split('|')
ValueError: need more than 1 value to unpack
```

This wrap the split call in a try and reports a warning instead of failing the aggregation run.
