### PR TITLE
updated carbon_sync to be able to handle configs without default 'main' ...

### DIFF
--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -172,7 +172,7 @@ def carbon_sync():
 
     config = Config(args.config_file)
 
-    user = config.ssh_user()
+    user = config.ssh_user(args.cluster)
     remote_ip = args.source_node
     remote = "%s@%s:%s/" % (user, remote_ip, args.source_storage_dir)
 


### PR DESCRIPTION
Ran into a little issue using carbon-sync.  I was specifying a carbonate.conf without a "main" cluster.  It was resulting in the ssh_user method in config.py throwing the following error:

```
$ carbon-sync -s source -c carbonate.conf -C old_cluster
Cluster 'main' not defined in carbonate.conf
```

This looks to be a simple fix.  Tests pass.  Great tool!
