### PR TITLE
'carbon-stale' tool to help find metrics with blank/missing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ optional arguments:
 usage: carbon-stale [-h] [-c CONFIG_FILE] [-C CLUSTER] [-f METRICS_FILE] [-r]
                     [-d STORAGE_DIR] [-l HOURS] [-w] [-p]
 
-Transform metric paths to (or from) filesystem paths
+Find and list potentially stale metrics.
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/README.md
+++ b/README.md
@@ -288,6 +288,37 @@ LOCAL_IP="$1"
 carbon-list | carbon-sieve -I -n $LOCAL_IP
 ```
 
+### Listing metrics that have stopped updating
+
+Metrics with whisper data that is entirely blank for the last 2 hours:
+
+```
+carbon-list | carbon-stale --limit=2
+```
+
+Metrics whose metrics files are untouched for 48 hours or more (functionally
+identical to `find /your/data/dir -type f -mtime +2`):
+
+```
+carbon-list | carbon-stale --stat --limit=48
+```
+
+More interesting is if you use ``carbon-stale``, then sieve to identify stale
+metrics that don't belong here (vs un-stale metrics that *do* belong here but
+are misreported in carbon-sieve due to things like doubled-up periods in metric
+paths due to broken collectors. It's a thing.)
+
+```
+carbon-list | carbon-stale --limit=48 | carbon-sieve -I -n $LOCAL_IP
+```
+
+To print file paths for use with e.g. `xargs rm` or whatnot, use `-p`:
+
+```
+carbon-list | carbon-stale -p | xargs -n 100 rm
+```
+
+
 # License and warnings
 
 These tools should be considered beta quality right now. Tests exist for most functionality, but there is still significant work to be done to make them bullet-proof. However, instead of sitting on this code, I'd rather release it and allow others to provide input and help guide the development. So, expect a few bugs and please help me fix them!

--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ optional arguments:
 
 ```
 usage: carbon-stale [-h] [-c CONFIG_FILE] [-C CLUSTER] [-f METRICS_FILE] [-r]
-                    [-d STORAGE_DIR] [-l HOURS] [-s]
+          [-d STORAGE_DIR] [-l HOURS] [-s] [-p]
 
-Given a list of metrics, select those which appear stale
+Transform metric paths to (or from) filesystem paths
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -188,16 +188,17 @@ optional arguments:
   -C CLUSTER, --cluster CLUSTER
                         Cluster name (default: main)
   -f METRICS_FILE, --metrics-file METRICS_FILE
-                        File containing metric names to filter against, or '-'
-                        to read from STDIN (default: -)
+                        File containing metric names to transform to file
+                        paths, or '-' to read from STDIN (default: -)
   -r, --reverse         Output metrics which are not stale instead (default:
                         False)
   -d STORAGE_DIR, --storage-dir STORAGE_DIR
-                        Whisper storage directory to look in when testing
-                        metrics (default: /opt/graphite/storage/whisper)
-  -l HOURS, --limit=HOURS Definition of staleness, in hours (default: 24)
-  -s, --stat            Use filesystem stat() call instead of reading whisper
-                        data (default: False)
+                        Whisper storage directory to prepend when -p given
+                        (default: /opt/graphite/storage/whisper)
+  -l HOURS, --limit HOURS
+                        Definition of staleness, in hours (default: 24)
+  -s, --stat            Use filesystem stat() call instead of whisper data
+                        (default: False)
   -p, --paths           Print filesystem paths instead of metric names
                         (default: False)
 ```

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ optional arguments:
 
 ```
 usage: carbon-stale [-h] [-c CONFIG_FILE] [-C CLUSTER] [-f METRICS_FILE] [-r]
-          [-d STORAGE_DIR] [-l HOURS] [-s] [-p]
+                    [-d STORAGE_DIR] [-l HOURS] [-w] [-p]
 
 Transform metric paths to (or from) filesystem paths
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ optional arguments:
                         (default: /opt/graphite/storage/whisper)
   -l HOURS, --limit HOURS
                         Definition of staleness, in hours (default: 24)
-  -s, --stat            Use filesystem stat() call instead of whisper data
+  -w, --whisper         Use whisper data instead of filesystem stat() call
                         (default: False)
   -p, --paths           Print filesystem paths instead of metric names
                         (default: False)
@@ -291,17 +291,19 @@ carbon-list | carbon-sieve -I -n $LOCAL_IP
 
 ### Listing metrics that have stopped updating
 
-Metrics with whisper data that is entirely blank for the last 2 hours:
+Metrics with whisper data that is entirely blank for the last 2 hours (perhaps
+useful if you suspect issues with fs timestamps or carbon clients writing in 'the
+future'):
 
 ```
-carbon-list | carbon-stale --limit=2
+carbon-list | carbon-stale --whisper --limit=2
 ```
 
-Metrics whose metrics files are untouched for 48 hours or more (functionally
+Metrics whose metrics files appear untouched for 48 hours or more (functionally
 identical to `find /your/data/dir -type f -mtime +2`):
 
 ```
-carbon-list | carbon-stale --stat --limit=48
+carbon-list | carbon-stale --limit=48
 ```
 
 More interesting is if you use ``carbon-stale``, then sieve to identify stale

--- a/README.md
+++ b/README.md
@@ -172,6 +172,36 @@ optional arguments:
                         (default: /opt/graphite/storage/whisper)
 ```
 
+### carbon-stale
+
+```
+usage: carbon-stale [-h] [-c CONFIG_FILE] [-C CLUSTER] [-f METRICS_FILE] [-r]
+                    [-d STORAGE_DIR] [-l HOURS] [-s]
+
+Given a list of metrics, select those which appear stale
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c CONFIG_FILE, --config-file CONFIG_FILE
+                        Config file to use (default:
+                        /opt/graphite/conf/carbonate.conf)
+  -C CLUSTER, --cluster CLUSTER
+                        Cluster name (default: main)
+  -f METRICS_FILE, --metrics-file METRICS_FILE
+                        File containing metric names to filter against, or '-'
+                        to read from STDIN (default: -)
+  -r, --reverse         Output metrics which are not stale instead (default:
+                        False)
+  -d STORAGE_DIR, --storage-dir STORAGE_DIR
+                        Whisper storage directory to look in when testing
+                        metrics (default: /opt/graphite/storage/whisper)
+  -l HOURS, --limit=HOURS Definition of staleness, in hours (default: 24)
+  -s, --stat            Use filesystem stat() call instead of reading whisper
+                        data (default: False)
+  -p, --paths           Print filesystem paths instead of metric names
+                        (default: False)
+```
+
 ### whisper-aggregate
 
 ```

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -286,9 +286,9 @@ def carbon_stale():
         help='Definition of staleness, in hours')
 
     parser.add_argument(
-        '-s', '--stat',
+        '-w', '--whisper',
         action='store_true',
-        help='Use filesystem stat() call instead of whisper data')
+        help='Use whisper data instead of filesystem stat() call')
 
     parser.add_argument(
         '-p', '--paths',
@@ -299,7 +299,7 @@ def carbon_stale():
     metrics = metrics_from_args(args)
     prefix = args.storage_dir
     for path in map(partial(metric_to_fs, prepend=prefix), metrics):
-        passed = (stat if args.stat else data)(path, args.limit)
+        passed = (data if args.whisper else stat)(path, args.limit)
         value = path if args.paths else fs_to_metric(path, prepend=prefix)
         if (not passed) if args.reverse else passed:
             print value

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -12,6 +12,7 @@ from .fill import fill_archives
 from .list import listMetrics
 from .lookup import lookup
 from .sieve import filterMetrics
+from .stale import data, stat
 from .sync import run_batch
 from .util import (
     local_addresses, common_parser, metric_to_fs, fs_to_metric,
@@ -296,12 +297,12 @@ def carbon_stale():
 
     args = parser.parse_args()
     metrics = metrics_from_args(args)
-    # define utils (or new module) funcs for staleness
-    # iterate over map(partial(metric_to_fs, prepend=args.storage_dir),
-    # metrics)
-    # test = one of those functions partial'd with args.limit
-    # then test with or without 'not' based on args.reverse
-    # finally print x if args.paths else fs_to_metric(x)
+    prefix = args.storage_dir
+    for path in map(partial(metric_to_fs, prepend=prefix), metrics):
+        passed = (stat if args.stat else data)(path, args.limit)
+        value = path if args.paths else fs_to_metric(path, prepend=prefix)
+        if (not passed) if args.reverse else passed:
+            print value
 
 
 def whisper_aggregate():

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -261,13 +261,13 @@ def carbon_stale():
     # Use common_parser for consistency, even though we do not use any config
     # file options at present.
     parser = common_parser(
-        'Transform metric paths to (or from) filesystem paths'
+        'Find and list potentially stale metrics.'
     )
 
     parser.add_argument(
         '-f', '--metrics-file',
         default='-',
-        help='File containing metric names to transform to file paths, or ' +
+        help='File containing metric names to scan for staleness, or ' +
         '\'-\' to read from STDIN')
 
     parser.add_argument(

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -252,6 +252,54 @@ def carbon_path():
         print func(metric)
 
 
+def carbon_stale():
+    # Use common_parser for consistency, even though we do not use any config
+    # file options at present.
+    parser = common_parser(
+        'Transform metric paths to (or from) filesystem paths'
+    )
+
+    parser.add_argument(
+        '-f', '--metrics-file',
+        default='-',
+        help='File containing metric names to transform to file paths, or ' +
+        '\'-\' to read from STDIN')
+
+    parser.add_argument(
+        '-r', '--reverse',
+        action='store_true',
+        help='Output metrics which are not stale instead')
+
+    parser.add_argument(
+        '-d', '--storage-dir',
+        default=STORAGE_DIR,
+        help='Whisper storage directory to prepend when -p given')
+
+    parser.add_argument(
+        '-l', '--limit', metavar='HOURS',
+        type=int, default=24,
+        help='Definition of staleness, in hours')
+
+    parser.add_argument(
+        '-s', '--stat',
+        action='store_true',
+        help='Use filesystem stat() call instead of whisper data')
+
+    parser.add_argument(
+        '-p', '--paths',
+        action='store_true',
+        help='Print filesystem paths instead of metric names')
+
+    args = parser.parse_args()
+    metrics = metrics_from_args(args)
+    # define utils (or new module) funcs for staleness
+    # iterate over map(partial(metric_to_fs, prepend=args.storage_dir),
+    # metrics)
+    # test = one of those functions partial'd with args.limit
+    # then test with or without 'not' based on args.reverse
+    # finally print x if args.paths else fs_to_metric(x)
+
+
 def whisper_aggregate():
     parser = argparse.ArgumentParser(
         description='Set aggregation for whisper-backed metrics this carbon ' +

--- a/carbonate/stale.py
+++ b/carbonate/stale.py
@@ -1,0 +1,23 @@
+import time
+import os
+
+import whisper
+
+
+def _limit(hours):
+    return time.time() - (hours * 60 * 60)
+
+
+def data(path, hours):
+    """
+    Does the metric at ``path`` have any whisper data newer than ``hours``?
+    """
+    _data = whisper.fetch(path, _limit(hours))
+    return all(x is None for x in _data[-1])
+
+
+def stat(path, hours):
+    """
+    Has the metric file at ``path`` been modified since ``hours`` ago?
+    """
+    return os.stat(path).st_mtime < _limit(hours)

--- a/carbonate/stale.py
+++ b/carbonate/stale.py
@@ -16,7 +16,7 @@ def data(path, hours, offset=0):
     ago, instead of from right now.
     """
     now = time.time()
-    end = now - _to_sec(offset) # Will default to now
+    end = now - _to_sec(offset)  # Will default to now
     start = end - _to_sec(hours)
     _data = whisper.fetch(path, start, end)
     return all(x is None for x in _data[-1])

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
             'carbon-list = carbonate.cli:carbon_list',
             'carbon-hosts = carbonate.cli:carbon_hosts',
             'carbon-path = carbonate.cli:carbon_path',
+            'carbon-stale = carbonate.cli:carbon_stale',
             'whisper-fill = carbonate.cli:whisper_fill',
             'whisper-aggregate = carbonate.cli:whisper_aggregate'
             ]


### PR DESCRIPTION
I found this need as I was trying to sanity-verify a cluster during partial outages - primarily sanity checking after running `carbon-sync` to make sure the data I expected to be backfilled, was.

There may be more work that could be done on this to make it even more useful but for now it fills that use case reasonably well (IMHO of course).