### PR TITLE
Fix default node argument for sieve

### DIFF
--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -99,7 +99,6 @@ def carbon_sieve():
 
     parser.add_argument(
         '-n', '--node',
-        default="self",
         help='Filter for metrics belonging to this node')
 
     parser.add_argument(


### PR DESCRIPTION
When --node is not specified, self was set instead of None
it prevent the code from using local_addresses
