### PR TITLE
lock whisper files during carbon-sync and whisper-fill

### DIFF
--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -181,6 +181,8 @@ def carbon_sync():
     remote_ip = args.source_node
     remote = "%s@%s:%s/" % (user, remote_ip, args.source_storage_dir)
 
+    whisper_lock_writes = config.whisper_lock_writes(args.config_file)
+
     metrics_to_sync = []
     metrics = metrics_from_args(args)
 
@@ -200,14 +202,15 @@ def carbon_sync():
                   % (total_metrics-batch_size+1, total_metrics)
             run_batch(metrics_to_sync, remote,
                       args.storage_dir, args.rsync_options,
-                      remote_ip, args.dirty)
+                      remote_ip, args.dirty, whisper_lock_writes)
             metrics_to_sync = []
 
     if len(metrics_to_sync) > 0:
         print "* Running batch %s-%s" \
               % (total_metrics-len(metrics_to_sync)+1, total_metrics)
         run_batch(metrics_to_sync, remote,
-                  args.storage_dir, args.rsync_options, remote_ip, args.dirty)
+                  args.storage_dir, args.rsync_options,
+                  remote_ip, args.dirty, whisper_lock_writes)
 
     elapsed = (time() - start)
 

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -320,6 +320,12 @@ def whisper_fill():
         metavar='DST',
         help='Whisper destination file')
 
+    parser.add_argument(
+        '-l', '--lock',
+        default=False,
+        action='store_true',
+        help='Lock whisper files during filling')
+
     args = parser.parse_args()
 
     src = args.source
@@ -333,4 +339,4 @@ def whisper_fill():
 
     startFrom = time()
 
-    fill_archives(src, dst, startFrom)
+    fill_archives(src, dst, startFrom, args.lock)

--- a/carbonate/config.py
+++ b/carbonate/config.py
@@ -42,3 +42,13 @@ class Config():
             return self.config.get(cluster, 'ssh_user')
         except NoOptionError:
             return pwd.getpwuid(os.getuid()).pw_name
+
+    def whisper_lock_writes(self, cluster='main'):
+        """Lock whisper files during carbon-sync."""
+        if not self.config.has_section(cluster):
+            raise SystemExit("Cluster '%s' not defined in %s"
+                             % (cluster, self.config_file))
+        try:
+            return bool(self.config.get(cluster, 'whisper_lock_writes'))
+        except NoOptionError:
+            return False

--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -37,7 +37,7 @@ def sync_from_remote(sync_file, remote, staging, rsync_options):
         logging.warn("Failed to sync from %s! %s" % (remote, e))
 
 
-def sync_batch(metrics_to_heal):
+def sync_batch(metrics_to_heal, lock_writes):
     batch_start = time()
     sync_count = 0
     sync_total = len(metrics_to_heal)
@@ -54,7 +54,7 @@ def sync_batch(metrics_to_heal):
                          sync_remain, sync_percent)
         print status_line
 
-        heal_metric(staging, local)
+        heal_metric(staging, local, lock_writes)
 
         sync_elapsed = time() - sync_start
         sync_avg = sync_elapsed / sync_count
@@ -65,11 +65,11 @@ def sync_batch(metrics_to_heal):
     return batch_elapsed
 
 
-def heal_metric(source, dest):
+def heal_metric(source, dest, lock_writes):
     try:
         with open(dest):
             try:
-                fill_archives(source, dest, time())
+                fill_archives(source, dest, time(), lock_writes)
             except CorruptWhisperFile as e:
                 logging.warn("Overwriting corrupt file %s!" % dest)
                 try:
@@ -92,7 +92,7 @@ def heal_metric(source, dest):
 
 
 def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
-              remote_ip, dirty):
+              remote_ip, dirty, lock_writes):
     staging_dir = mkdtemp(prefix=remote_ip)
     sync_file = NamedTemporaryFile(delete=False)
 
@@ -114,7 +114,7 @@ def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
 
     rsync_elapsed = (time() - rsync_start)
 
-    merge_elapsed = sync_batch(metrics_to_heal)
+    merge_elapsed = sync_batch(metrics_to_heal, lock_writes)
 
     total_time = rsync_elapsed + merge_elapsed
 

--- a/tests/test_fill.py
+++ b/tests/test_fill.py
@@ -39,7 +39,7 @@ class FillTest(unittest.TestCase):
         self._createdb(self.db, schema)
         self._createdb(testdb, schema, emptyData)
 
-        fill_archives(self.db, testdb, startTime)
+        fill_archives(self.db, testdb, startTime, False)
 
         original_data = whisper.fetch(self.db, 0)
         filled_data = whisper.fetch(testdb, 0)
@@ -70,7 +70,7 @@ class FillTest(unittest.TestCase):
         self._createdb(self.db, schema)
         self._createdb(testdb, schema, override_data)
 
-        fill_archives(self.db, testdb, startTime)
+        fill_archives(self.db, testdb, startTime, False)
 
         original_data = whisper.fetch(self.db, 0)
         filled_data = whisper.fetch(testdb, 0)
@@ -102,7 +102,7 @@ class FillTest(unittest.TestCase):
         self._createdb(self.db, schema, complete_data)
         self._createdb(testdb, schema, holes_data)
 
-        fill_archives(self.db, testdb, time.time())
+        fill_archives(self.db, testdb, time.time(), False)
 
         original_data = whisper.fetch(self.db, 0)
         filled_data = whisper.fetch(testdb, 0)


### PR DESCRIPTION
as discussed on #47, the option isn't symmetric between sync and fill (config file vs command line) however fill doesn't take a config file anyway. Also I noticed whisper-fill is included in graphite's distribution too so that will need updating as well.