### PR TITLE
add support for aggregated consistent hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ Carbonate expects a configuration file that defines the clusters in your environ
 ```
 [main]
 DESTINATIONS = 192.168.9.13:2004:carbon01, 192.168.9.15:2004:carbon02, 192.168.6.20:2004:carbon03
+RELAY_METHOD = aggregated-consistent-hashing
 REPLICATION_FACTOR = 2
 SSH_USER = carbon
 ```
 
 You should take care to match the list of destination IPs or hostnames to the nodes in your cluster. Though its worth noting that the ports and labels are currently not used by carbonate. Order is important because of how the consistent hash ring is created.
+
+You can configure the relay method to be one of "consistent-hashing" or "aggregated-consistent-hashing". If omitted, "consistent-hashing" is used by default. Use of "aggregated-consistent-hashing" usually requires a rules file to be provided to relevant commands.
 
 The replication factor should match the replication factor for the cluster.
 
@@ -67,6 +70,10 @@ optional arguments:
                         /opt/graphite/conf/carbonate.conf)
   -C CLUSTER, --cluster CLUSTER
                         Cluster name (default: main)
+  -a AGGREGATION_RULES, --aggregation-rules AGGREGATION_RULES
+                        File containing rules used in conjunction with the
+                        "aggregated-consistent-hashing" relay method (default:
+                        /opt/graphite/conf/aggregation-rules.conf)
   -s, --short           Only display the address, without port and cluster
                         name (default: False)
 ```
@@ -107,6 +114,10 @@ optional arguments:
   -f METRICS_FILE, --metrics-file METRICS_FILE
                         File containing metric names to filter, or '-' to read
                         from STDIN (default: -)
+  -a AGGREGATION_RULES, --aggregation-rules AGGREGATION_RULES
+                        File containing rules used in conjunction with the
+                        "aggregated-consistent-hashing" relay method (default:
+                        /opt/graphite/conf/aggregation-rules.conf)
   -n NODE, --node NODE  Filter for metrics belonging to this node (default:
                         self)
   -I, --invert          Invert the sieve, match metrics that do NOT belong to

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -69,6 +69,12 @@ def carbon_lookup():
         help='Full metric name to search for')
 
     parser.add_argument(
+        '-a', '--aggregation-rules',
+        default='/opt/graphite/conf/aggregation-rules.conf',
+        help='File containing rules used in conjunction with the ' +
+             '"aggregated-consistent-hashing" relay method')
+
+    parser.add_argument(
         '-s', '--short',
         action='store_true',
         help='Only display the address, without port and cluster name')
@@ -76,7 +82,7 @@ def carbon_lookup():
     args = parser.parse_args()
 
     config = Config(args.config_file)
-    cluster = Cluster(config, args.cluster)
+    cluster = Cluster(config, args.cluster, args.aggregation_rules)
 
     results = lookup(str(args.metric[0]), cluster)
 
@@ -98,6 +104,12 @@ def carbon_sieve():
              'to read from STDIN')
 
     parser.add_argument(
+        '-a', '--aggregation-rules',
+        default='/opt/graphite/conf/aggregation-rules.conf',
+        help='File containing rules used in conjunction with the ' +
+             '"aggregated-consistent-hashing" relay method')
+
+    parser.add_argument(
         '-n', '--node',
         help='Filter for metrics belonging to this node. Uses the local ' +
              'addresses if not provided.')
@@ -110,7 +122,7 @@ def carbon_sieve():
     args = parser.parse_args()
 
     config = Config(args.config_file)
-    cluster = Cluster(config, args.cluster)
+    cluster = Cluster(config, args.cluster, args.aggregation_rules)
     invert = args.invert
 
     metrics = metrics_from_args(args)

--- a/carbonate/cluster.py
+++ b/carbonate/cluster.py
@@ -6,14 +6,21 @@ sys.path.insert(0, '/opt/graphite/lib')
 # We're going to use carbon's libs directly to do things
 try:
     from carbon import util
-    from carbon.routers import ConsistentHashingRouter
+    from carbon.aggregator.rules import RuleManager
+    from carbon.routers import AggregatedConsistentHashingRouter, ConsistentHashingRouter
 except ImportError as e:
     raise SystemExit("No bueno. Can't import carbon! (" + str(e) + ")")
 
 
 class Cluster():
-    def __init__(self, config, cluster='main'):
-        self.ring = ConsistentHashingRouter(config.replication_factor(cluster))
+    def __init__(self, config, cluster='main', aggregation_rules=None):
+        relay_method = config.relay_method(cluster=cluster)
+        if relay_method == "consistent-hashing":
+            self.ring = ConsistentHashingRouter(config.replication_factor(cluster))
+        elif relay_method == "aggregated-consistent-hashing":
+            if aggregation_rules:
+                RuleManager.read_from(aggregation_rules)
+            self.ring = AggregatedConsistentHashingRouter(RuleManager, config.replication_factor(cluster))
 
         try:
             dest_list = config.destinations(cluster)

--- a/carbonate/config.py
+++ b/carbonate/config.py
@@ -26,6 +26,13 @@ class Config():
         destinations = self.config.get(cluster, 'destinations')
         return destinations.replace(' ', '').split(',')
 
+    def relay_method(self, cluster='main'):
+        """Return the carbon relay method for a cluster."""
+        if not self.config.has_section(cluster):
+            raise SystemExit("Cluster '%s' not defined in %s"
+                             % (cluster, self.config_file))
+        return self.config.get(cluster, 'relay_method')
+
     def replication_factor(self, cluster='main'):
         """Return the replication factor for a cluster as an integer."""
         if not self.config.has_section(cluster):


### PR DESCRIPTION
You can configure the relay method to be one of "consistent-hashing" or "aggregated-consistent-hashing". If omitted, "consistent-hashing" is used by default. Use of "aggregated-consistent-hashing" usually requires a rules file to be provided to relevant commands. This can be provided on the command line.
