### PR TITLE
Fix reading whisper_lock_writes from cluster config in carbon_sync

### DIFF
--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -193,7 +193,7 @@ def carbon_sync():
     remote_ip = args.source_node
     remote = "%s@%s:%s/" % (user, remote_ip, args.source_storage_dir)
 
-    whisper_lock_writes = config.whisper_lock_writes(args.config_file) or \
+    whisper_lock_writes = config.whisper_lock_writes(args.cluster) or \
         args.lock
 
     metrics_to_sync = []


### PR DESCRIPTION
When running a carbon_sync, I see the following error:
> Cluster '/opt/graphite/conf/carbonate.conf' not defined in /opt/graphite/conf/carbonate.conf

This can be resolved by passing the cluster name into the whisper_lock_writes function on the config object.