### PR TITLE
Removing "beta quality" statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,8 +325,9 @@ carbon-list | carbon-stale -p | xargs -n 100 rm
 ```
 
 
-# License and warnings
-
-These tools should be considered beta quality right now. Tests exist for most functionality, but there is still significant work to be done to make them bullet-proof. However, instead of sitting on this code, I'd rather release it and allow others to provide input and help guide the development. So, expect a few bugs and please help me fix them!
+# License
 
 The code is available under the MIT license.
+
+
+


### PR DESCRIPTION
It's mature enough for a long time already, and reach 1.0.0 together with Graphite.