### PR TITLE
nodes is required param in carbon ConsistentHashRing

### DIFF
--- a/carbonate/cluster.py
+++ b/carbonate/cluster.py
@@ -30,18 +30,18 @@ class Cluster():
                 DIVERSE_REPLICAS = False
             r = ConsistentHashingRouter(Settings())
 
-        # 'hash_type' was added only in carbon 1.0.2 or master
-        args = inspect.getargspec(ConsistentHashRing.__init__).args
-        if 'hash_type' in args:
-            r.ring = ConsistentHashRing(hash_type=config.hashing_type(cluster))
-
-        self.ring = r
-
         try:
             dest_list = config.destinations(cluster)
             self.destinations = util.parseDestinations(dest_list)
         except ValueError as e:
             raise SystemExit("Unable to parse destinations!" + str(e))
+
+        # 'hash_type' was added only in carbon 1.0.2 or master
+        args = inspect.getargspec(ConsistentHashRing.__init__).args
+        if 'hash_type' in args:
+            r.ring = ConsistentHashRing(nodes=self.destinations,hash_type=config.hashing_type(cluster))
+
+        self.ring = r
 
         for d in self.destinations:
             self.ring.addDestination(d)


### PR DESCRIPTION
fixes https://github.com/graphite-project/carbonate/issues/85
when self.destinations is parsed we pass it to ConsistentHashRing as nodes. 