### PR TITLE
carbon-sync: expose --overwrite to copy all non-null datapoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ optional arguments:
   --dirty               If set, don't clean temporary rsync directory
                         (default: False)
   -l, --lock            Lock whisper files during filling (default: False)
-  -o, --overwite        Write all non nullpoints from src to dst (default:
+  -o, --overwrite        Write all non nullpoints from src to dst (default:
                         False)
 ```
 
@@ -253,7 +253,7 @@ positional arguments:
 optional arguments:
   -h, --help      show this help message and exit
   -l, --lock      Lock whisper files during filling (default: False)
-  -o, --overwite  Write all non nullpoints from src to dst (default: False)
+  -o, --overwrite  Write all non nullpoints from src to dst (default: False)
 ```
 
 ## Example usage

--- a/README.md
+++ b/README.md
@@ -129,17 +129,17 @@ optional arguments:
 usage: carbon-sync [-h] [-c CONFIG_FILE] [-C CLUSTER] [-f METRICS_FILE] -s
                    SOURCE_NODE [-d STORAGE_DIR] [-b BATCH_SIZE]
                    [--source-storage-dir SOURCE_STORAGE_DIR]
-                   [--rsync-options [RSYNC_OPTIONS [RSYNC_OPTIONS ...]]]
+                   [--rsync-options RSYNC_OPTIONS] [--dirty] [-l] [-o]
 
 Sync local metrics using remote nodes in the cluster
 
 optional arguments:
   -h, --help            show this help message and exit
   -c CONFIG_FILE, --config-file CONFIG_FILE
-                        Config file to use (default:
+                        Config file to use (env: CARBONATE_CONFIG) (default:
                         /opt/graphite/conf/carbonate.conf)
   -C CLUSTER, --cluster CLUSTER
-                        Cluster name (default: main)
+                        Cluster name (env: CARBONATE_CLUSTER) (default: main)
   -f METRICS_FILE, --metrics-file METRICS_FILE
                         File containing metric names to filter, or '-' to read
                         from STDIN (default: -)
@@ -152,8 +152,14 @@ optional arguments:
   --source-storage-dir SOURCE_STORAGE_DIR
                         Source storage dir (default:
                         /opt/graphite/storage/whisper)
-  --rsync-options [RSYNC_OPTIONS [RSYNC_OPTIONS ...]]
-                        Pass option(s) to rsync (default: -azpS)
+  --rsync-options RSYNC_OPTIONS
+                        Pass option(s) to rsync. Make sure to use "--rsync-
+                        options=" if option starts with '-' (default: -azpS)
+  --dirty               If set, don't clean temporary rsync directory
+                        (default: False)
+  -l, --lock            Lock whisper files during filling (default: False)
+  -o, --overwite        Write all non nullpoints from src to dst (default:
+                        False)
 ```
 
 ### carbon-path
@@ -236,16 +242,18 @@ optional arguments:
 ### whisper-fill
 
 ```
-usage: whisper-fill [-h] SRC DST
+usage: whisper-fill [-h] [-l] [-o] SRC DST
 
 Backfill datapoints from one whisper file into another
 
 positional arguments:
-  SRC         Whisper source file
-  DST         Whisper destination file
+  SRC             Whisper source file
+  DST             Whisper destination file
 
 optional arguments:
-  -h, --help  show this help message and exit
+  -h, --help      show this help message and exit
+  -l, --lock      Lock whisper files during filling (default: False)
+  -o, --overwite  Write all non nullpoints from src to dst (default: False)
 ```
 
 ## Example usage

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -184,7 +184,7 @@ def carbon_sync():
         help='Lock whisper files during filling')
 
     parser.add_argument(
-        '-o', '--overwite',
+        '-o', '--overwrite',
         default=False,
         dest='overwrite',
         action='store_true',
@@ -402,7 +402,7 @@ def whisper_fill():
         help='Lock whisper files during filling')
 
     parser.add_argument(
-        '-o', '--overwite',
+        '-o', '--overwrite',
         default=False,
         dest='overwrite',
         action='store_true',

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -183,6 +183,12 @@ def carbon_sync():
         action='store_true',
         help='Lock whisper files during filling')
 
+    parser.add_argument(
+        '-o', '--overwite',
+        default=False,
+        action='store_true',
+        help='Write all non nullpoints from src to dst')
+
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
@@ -215,7 +221,8 @@ def carbon_sync():
                   % (total_metrics-batch_size+1, total_metrics)
             run_batch(metrics_to_sync, remote,
                       args.storage_dir, args.rsync_options,
-                      remote_ip, args.dirty, lock_writes=whisper_lock_writes)
+                      remote_ip, args.dirty, lock_writes=whisper_lock_writes,
+                      overwrite=args.overwrite)
             metrics_to_sync = []
 
     if len(metrics_to_sync) > 0:
@@ -393,6 +400,12 @@ def whisper_fill():
         action='store_true',
         help='Lock whisper files during filling')
 
+    parser.add_argument(
+        '-o', '--overwite',
+        default=False,
+        action='store_true',
+        help='Write all non nullpoints from src to dst')
+
     args = parser.parse_args()
 
     src = args.source
@@ -406,4 +419,4 @@ def whisper_fill():
 
     startFrom = time()
 
-    fill_archives(src, dst, startFrom, lock_writes=args.lock)
+    fill_archives(src, dst, startFrom, lock_writes=args.lock, overwrite=args.overwrite)

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -186,6 +186,7 @@ def carbon_sync():
     parser.add_argument(
         '-o', '--overwite',
         default=False,
+        dest='overwrite',
         action='store_true',
         help='Write all non nullpoints from src to dst')
 
@@ -403,6 +404,7 @@ def whisper_fill():
     parser.add_argument(
         '-o', '--overwite',
         default=False,
+        dest='overwrite',
         action='store_true',
         help='Write all non nullpoints from src to dst')
 

--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -37,7 +37,7 @@ def sync_from_remote(sync_file, remote, staging, rsync_options):
         logging.warn("Failed to sync from %s! %s" % (remote, e))
 
 
-def sync_batch(metrics_to_heal, lock_writes=False):
+def sync_batch(metrics_to_heal, lock_writes=False, overwrite=False):
     batch_start = time()
     sync_count = 0
     sync_total = len(metrics_to_heal)
@@ -58,6 +58,7 @@ def sync_batch(metrics_to_heal, lock_writes=False):
         # Do not try healing data past the point they were rsync'd
         # as we would not have new points in staging anyway.
         heal_metric(staging, local, end_time=batch_start,
+                    overwrite=overwrite,
                     lock_writes=lock_writes)
 
         sync_elapsed += time() - sync_start
@@ -115,7 +116,7 @@ def heal_metric(source, dest, start_time=0, end_time=None, overwrite=False,
 
 
 def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
-              remote_ip, dirty, lock_writes=False):
+              remote_ip, dirty, lock_writes=False, overwrite=False):
     staging_dir = mkdtemp(prefix=remote_ip)
     sync_file = NamedTemporaryFile(delete=False)
 
@@ -137,7 +138,7 @@ def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
 
     rsync_elapsed = (time() - rsync_start)
 
-    merge_elapsed = sync_batch(metrics_to_heal, lock_writes=lock_writes)
+    merge_elapsed = sync_batch(metrics_to_heal, lock_writes=lock_writes, overwrite=overwrite)
 
     total_time = rsync_elapsed + merge_elapsed
 


### PR DESCRIPTION
Currently if you have data files

A: `1, None, 3, 4`
B: `1, 2, None, 4`

`carbon-sync` will not sync the missing gaps in the data as you might expect. This exposes a `--overwrite` flag (which is probably poorly named, but carries on the existing function argument) to copy all non-null datapoints so that a sync in  either direction would result in the data file `1, 2, 3, 4`