### PR TITLE
fill: fix bugs causing some data points not to be copied

### DIFF
--- a/carbonate/fill.py
+++ b/carbonate/fill.py
@@ -95,7 +95,7 @@ def fill_archives(src, dst, startFrom, endAt=0, overwrite=False,
     startFrom is the latest timestamp (archives are read backward)
     endAt is the earliest timestamp (archives are read backward).
           if absent, we take the earliest timestamp in the archive
-    overwrite will write all non nullpoints from src dst.
+    overwrite will write all non null points from src dst.
     lock using whisper lock if true
     """
     if lock_writes is False:
@@ -120,14 +120,13 @@ def fill_archives(src, dst, startFrom, endAt=0, overwrite=False,
             if not has_value and not gapstart:
                 gapstart = start
             elif has_value and gapstart:
-                # ignore single units lost
-                if (start - gapstart) > archive['secondsPerPoint']:
+                if (start - gapstart) >= archive['secondsPerPoint']:
                     fill(src, dst, gapstart - step, start)
                 gapstart = None
-            elif gapstart and start == end - step:
-                fill(src, dst, gapstart - step, start)
-
             start += step
+        # fill if this gap continues to the end
+        if gapstart:
+            fill(src, dst, gapstart - step, end - step)
 
         # The next archive only needs to be filled up to the latest point
         # in time we updated.


### PR DESCRIPTION
In the process of #89 I realized that the issue i was having wasn't the need for an overwrite flag, but rather just a missunderstanding that the behaviour i was seeing was due to bugs in `fill` where some data wasn't being copied between whisper data files to fill gaps.

The two bugs are

a) missing data points equal to secondsPerPoint were not filled (in my real-world use case, secondsPerPoint==86400 so data points gaps of a day are not repaired, but multi-data-points are
b) trailing data gaps repaired (`fill` was not poperly called at the end of the loop)

I've updated test coverage to illustrate these bugs, and better codify expectations around fill with overwrite=False

cc: @deniszh @jssjr