### PR TITLE
Use the scandir version of os.walk if possible

### DIFF
--- a/carbonate/list.py
+++ b/carbonate/list.py
@@ -4,9 +4,9 @@ import re
 # Use the built-in version of scandir/walk if possible, otherwise
 # use the scandir module version
 try:
-    from os import scandir, walk
+    from os import scandir, walk  # noqa # pylint: disable=unused-import
 except ImportError:
-    from scandir import scandir, walk
+    from scandir import scandir, walk  # noqa # pylint: disable=unused-import
 
 
 def listMetrics(storage_dir, follow_sym_links=False, metric_suffix='wsp'):
@@ -14,8 +14,7 @@ def listMetrics(storage_dir, follow_sym_links=False, metric_suffix='wsp'):
 
     storage_dir = storage_dir.rstrip(os.sep)
 
-    for root, dirnames, filenames in walk(storage_dir,
-                                          followlinks=follow_sym_links):
+    for root, _, filenames in walk(storage_dir, followlinks=follow_sym_links):
         for filename in filenames:
             if metric_regex.match(filename):
                 root_path = root[len(storage_dir) + 1:]

--- a/carbonate/list.py
+++ b/carbonate/list.py
@@ -1,14 +1,21 @@
 import os
 import re
 
+# Use the built-in version of scandir/walk if possible, otherwise
+# use the scandir module version
+try:
+    from os import scandir, walk
+except ImportError:
+    from scandir import scandir, walk
+
 
 def listMetrics(storage_dir, follow_sym_links=False, metric_suffix='wsp'):
     metric_regex = re.compile(".*\.%s$" % metric_suffix)
 
     storage_dir = storage_dir.rstrip(os.sep)
 
-    for root, dirnames, filenames in os.walk(storage_dir,
-                                             followlinks=follow_sym_links):
+    for root, dirnames, filenames in walk(storage_dir,
+                                          followlinks=follow_sym_links):
         for filename in filenames:
             if metric_regex.match(filename):
                 root_path = root[len(storage_dir) + 1:]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 carbon
 whisper
+scandir

--- a/tests/old_whisper_requirements.txt
+++ b/tests/old_whisper_requirements.txt
@@ -1,3 +1,4 @@
 Twisted==11.1.0
 carbon
 whisper==0.9.9
+scandir


### PR DESCRIPTION
As carbon-list is used in pretty much all scenarios and scandir
is already being used in graphite-web we can speedup listing
metrics here also.