### PR TITLE
specify long_description_content_type, so that package description is properly rendered on pypi.org

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     include_package_data = True,
     packages=find_packages(),
     long_description = read('README.md'),
+    long_description_content_type='text/markdown',
     install_requires = [
       "carbon",
       "whisper",


### PR DESCRIPTION
Resolves https://github.com/graphite-project/carbonate/issues/103