### PR TITLE
Use --copy-dest, enabling the rsync algorithm when copying from remote to staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.eggs
 
 # Installer logs
 pip-log.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+python: 2.7
 language: python
 env:
   - TOXENV=py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 env:
   - TOXENV=py27
   - TOXENV=py27-pre0_9_10
+  - TOXENV=py3
   - TOXENV=lint
 install:
   - pip install tox

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ optional arguments:
 usage: carbon-sync [-h] [-c CONFIG_FILE] [-C CLUSTER] [-f METRICS_FILE] -s
                    SOURCE_NODE [-d STORAGE_DIR] [-b BATCH_SIZE]
                    [--source-storage-dir SOURCE_STORAGE_DIR]
-                   [--rsync-options RSYNC_OPTIONS] [--dirty] [-l] [-o]
+                   [--rsync-options RSYNC_OPTIONS] [--rsync-disable-copy-dest]
+                   [--dirty] [-l] [-o]
 
 Sync local metrics using remote nodes in the cluster
 
@@ -155,10 +156,13 @@ optional arguments:
   --rsync-options RSYNC_OPTIONS
                         Pass option(s) to rsync. Make sure to use "--rsync-
                         options=" if option starts with '-' (default: -azpS)
+  --rsync-disable-copy-dest
+                        Avoid --copy-dest, transfer all whisper data between
+                        nodes. (default: False)
   --dirty               If set, don't clean temporary rsync directory
                         (default: False)
   -l, --lock            Lock whisper files during filling (default: False)
-  -o, --overwrite        Write all non nullpoints from src to dst (default:
+  -o, --overwrite       Write all non nullpoints from src to dst (default:
                         False)
 ```
 

--- a/carbonate/aggregation.py
+++ b/carbonate/aggregation.py
@@ -28,5 +28,5 @@ def setAggregation(path, mode):
     try:
         whisper.setAggregationMethod(path, mode)
         return 1
-    except whisper.WhisperException, exc:
+    except whisper.WhisperException as exc:
         logging.warning("%s failed (%s)" % (path, str(exc)))

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -173,6 +173,12 @@ def carbon_sync():
         '"--rsync-options=" if option starts with \'-\'')
 
     parser.add_argument(
+        '--rsync-disable-copy-dest',
+        default=False,
+        action='store_true',
+        help='Avoid --copy-dest, transfer all whisper data between nodes.')
+
+    parser.add_argument(
         '--dirty',
         action='store_true',
         help="If set, don't clean temporary rsync directory")
@@ -210,6 +216,10 @@ def carbon_sync():
     total_metrics = 0
     batch_size = int(args.batch_size)
 
+    rsync_options = args.rsync_options
+    if not args.rsync_disable_copy_dest:
+        rsync_options += ' --copy-dest="%s"' % args.storage_dir
+
     for metric in metrics:
         total_metrics += 1
         metric = metric.strip()
@@ -221,7 +231,7 @@ def carbon_sync():
             print "* Running batch %s-%s" \
                   % (total_metrics-batch_size+1, total_metrics)
             run_batch(metrics_to_sync, remote,
-                      args.storage_dir, args.rsync_options,
+                      args.storage_dir, rsync_options,
                       remote_ip, args.dirty, lock_writes=whisper_lock_writes,
                       overwrite=args.overwrite)
             metrics_to_sync = []
@@ -230,7 +240,7 @@ def carbon_sync():
         print "* Running batch %s-%s" \
               % (total_metrics-len(metrics_to_sync)+1, total_metrics)
         run_batch(metrics_to_sync, remote,
-                  args.storage_dir, args.rsync_options,
+                  args.storage_dir, rsync_options,
                   remote_ip, args.dirty, lock_writes=whisper_lock_writes)
 
     elapsed = (time() - start)

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -36,7 +36,7 @@ def carbon_hosts():
 
     cluster_hosts = [d[0] for d in cluster.destinations]
 
-    print "\n".join(cluster_hosts)
+    print("\n".join(cluster_hosts))
 
 
 def carbon_list():
@@ -56,7 +56,7 @@ def carbon_list():
 
     try:
         for m in listMetrics(args.storage_dir, args.follow_sym_links):
-            print m
+            print(m)
     except IOError as e:
         if e.errno == errno.EPIPE:
             pass  # we got killed, lol
@@ -90,7 +90,7 @@ def carbon_lookup():
         for i, _ in enumerate(results):
             results[i] = results[i].split(':')[0]
 
-    print "\n".join(results)
+    print("\n".join(results))
 
 
 def carbon_sieve():
@@ -130,7 +130,7 @@ def carbon_sieve():
         for metric in metrics:
             m = metric.strip()
             for match in filterMetrics([m], match_dests, cluster, invert):
-                print metric.strip()
+                print(metric.strip())
     except KeyboardInterrupt:
         sys.exit(1)
 
@@ -228,8 +228,8 @@ def carbon_sync():
         metrics_to_sync.append(mpath)
 
         if total_metrics % batch_size == 0:
-            print "* Running batch %s-%s" \
-                  % (total_metrics-batch_size+1, total_metrics)
+            print("* Running batch %s-%s"
+                  % (total_metrics-batch_size+1, total_metrics))
             run_batch(metrics_to_sync, remote,
                       args.storage_dir, rsync_options,
                       remote_ip, args.dirty, lock_writes=whisper_lock_writes,
@@ -237,19 +237,19 @@ def carbon_sync():
             metrics_to_sync = []
 
     if len(metrics_to_sync) > 0:
-        print "* Running batch %s-%s" \
-              % (total_metrics-len(metrics_to_sync)+1, total_metrics)
+        print("* Running batch %s-%s"
+              % (total_metrics-len(metrics_to_sync)+1, total_metrics))
         run_batch(metrics_to_sync, remote,
                   args.storage_dir, rsync_options,
                   remote_ip, args.dirty, lock_writes=whisper_lock_writes)
 
     elapsed = (time() - start)
 
-    print ""
-    print "* Sync Report"
-    print "  ========================================"
-    print "  Total metrics synced: %s" % total_metrics
-    print "  Total time: %ss" % elapsed
+    print("")
+    print("* Sync Report")
+    print("  ========================================")
+    print("  Total metrics synced: %s" % total_metrics)
+    print("  Total time: %ss" % elapsed)
 
 
 def carbon_path():
@@ -293,7 +293,7 @@ def carbon_path():
         func = partial(metric_to_fs, prepend=prepend)
 
     for metric in metrics:
-        print func(metric)
+        print(func(metric))
 
 
 def carbon_stale():
@@ -347,7 +347,7 @@ def carbon_stale():
         passed = (data if use_whisper else stat)(path, args.limit, args.offset)
         value = path if args.paths else fs_to_metric(path, prepend=prefix)
         if (not passed) if args.reverse else passed:
-            print value
+            print(value)
 
 
 def whisper_aggregate():
@@ -383,7 +383,7 @@ def whisper_aggregate():
             if mode is not None:
                 path = metric_to_fs(name, prepend=args.storage_dir)
                 metrics_count = metrics_count + setAggregation(path, mode)
-        except ValueError, exc:
+        except ValueError as exc:
             logging.warning("Unable to parse '%s' (%s)" % (metric, str(exc)))
 
     logging.info('Successfully set aggregation mode for ' +

--- a/carbonate/config.py
+++ b/carbonate/config.py
@@ -1,6 +1,9 @@
 import os
 import pwd
-from ConfigParser import RawConfigParser, NoOptionError
+try:
+    from ConfigParser import RawConfigParser, NoOptionError
+except ImportError:
+    from configparser import RawConfigParser, NoOptionError
 
 
 class Config():

--- a/carbonate/fill.py
+++ b/carbonate/fill.py
@@ -14,6 +14,7 @@
 
 # Work performed by author while working at Booking.com.
 
+import time
 import whisper
 
 try:
@@ -22,8 +23,14 @@ try:
 except ImportError:
     HAS_OPERATOR = False
 
-import itertools
-import time
+try:
+    # Python 2
+    from future_builtins import filter
+    from future_builtins import zip
+    range = xrange
+except ImportError:
+    # Python 3
+    pass
 
 
 def itemgetter(*items):
@@ -71,9 +78,9 @@ def fill(src, dst, tstart, tstop):
 
         (timeInfo, values) = whisper.fetch(src, fromTime, untilTime)
         (start, end, archive_step) = timeInfo
-        pointsToWrite = list(itertools.ifilter(
+        pointsToWrite = list(filter(
             lambda points: points[1] is not None,
-            itertools.izip(xrange(start, end, archive_step), values)))
+            zip(range(start, end, archive_step), values)))
         # order points by timestamp, newest first
         pointsToWrite.sort(key=lambda p: p[0], reverse=True)
         whisper.update_many(dst, pointsToWrite)

--- a/carbonate/sieve.py
+++ b/carbonate/sieve.py
@@ -5,7 +5,7 @@ map_short = partial(map, lambda m: m[0])
 
 
 def filterMetrics(inputs, node, cluster, invert=False, filter_long=False):
-    if isinstance(node, basestring):
+    if isinstance(node, str):
         match = [node]
     else:
         match = node

--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -23,7 +23,7 @@ def sync_from_remote(sync_file, remote, staging, rsync_options):
                         sync_file.name, remote, staging
                         ])
 
-        print "  - Rsyncing metrics"
+        print("  - Rsyncing metrics")
 
         proc = subprocess.Popen(cmd,
                                 shell=True,
@@ -53,7 +53,7 @@ def sync_batch(metrics_to_heal, lock_writes=False, overwrite=False):
                       "Avg: %fs  Time Left: %ss (%d%%)" \
                       % (sync_count, sync_total, sync_avg,
                          sync_remain, sync_percent)
-        print status_line
+        print(status_line)
 
         # Do not try healing data past the point they were rsync'd
         # as we would not have new points in staging anyway.
@@ -143,14 +143,14 @@ def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
 
     total_time = rsync_elapsed + merge_elapsed
 
-    print "    --------------------------------------"
-    print "    Rsync time: %ss" % rsync_elapsed
-    print "    Merge time: %ss" % merge_elapsed
-    print "    Total time: %ss" % total_time
+    print("    --------------------------------------")
+    print("    Rsync time: %ss" % rsync_elapsed)
+    print("    Merge time: %ss" % merge_elapsed)
+    print("    Total time: %ss" % total_time)
 
     # Cleanup
     if dirty:
-        print "    dirty mode: left temporary directory %s" % staging_dir
+        print("    dirty mode: left temporary directory %s" % staging_dir)
     else:
         rmtree(staging_dir)
 

--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -12,15 +12,15 @@ from whisper import CorruptWhisperFile
 from .fill import fill_archives
 
 
-def sync_from_remote(storage_dir, sync_file, remote, staging, rsync_options):
+def sync_from_remote(sync_file, remote, staging, rsync_options):
     try:
         try:
             os.makedirs(os.path.dirname(staging))
         except OSError:
             pass
 
-        cmd = " ".join(['rsync', rsync_options, '--copy-dest', storage_dir,
-                        '--files-from', sync_file.name, remote, staging
+        cmd = " ".join(['rsync', rsync_options, '--files-from',
+                        sync_file.name, remote, staging
                         ])
 
         print "  - Rsyncing metrics"
@@ -115,7 +115,7 @@ def heal_metric(source, dest, start_time=0, end_time=None, overwrite=False,
             logging.warn("Failed to copy %s! %s" % (dest, e))
 
 
-def run_batch(metrics_to_sync, remote, storage_dir, rsync_options,
+def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
               remote_ip, dirty, lock_writes=False, overwrite=False):
     staging_dir = mkdtemp(prefix=remote_ip)
     sync_file = NamedTemporaryFile(delete=False)
@@ -126,7 +126,7 @@ def run_batch(metrics_to_sync, remote, storage_dir, rsync_options,
 
     for metric in metrics_to_sync:
         staging_file = "%s/%s" % (staging_dir, metric)
-        local_file = "%s/%s" % (storage_dir, metric)
+        local_file = "%s/%s" % (local_storage, metric)
         metrics_to_heal.append((staging_file, local_file))
 
     sync_file.write("\n".join(metrics_to_sync))
@@ -134,7 +134,7 @@ def run_batch(metrics_to_sync, remote, storage_dir, rsync_options,
 
     rsync_start = time()
 
-    sync_from_remote(storage_dir, sync_file, remote, staging, rsync_options)
+    sync_from_remote(sync_file, remote, staging, rsync_options)
 
     rsync_elapsed = (time() - rsync_start)
 

--- a/setup.py
+++ b/setup.py
@@ -6,15 +6,17 @@ from setuptools.command.install_scripts import install_scripts
 
 
 class my_install_scripts(install_scripts):
-  def write_script(self, script_name, contents, mode="t", *ignored):
-    contents = re.sub("import sys",
-                      "import sys\nsys.path.append('/opt/graphite/lib')",
-                      contents)
-    install_scripts.write_script(self, script_name, contents, mode="t", *ignored)
+    def write_script(self, script_name, contents, mode="t", *ignored):
+        contents = re.sub("import sys",
+                          "import sys\nsys.path.append('/opt/graphite/lib')",
+                          contents)
+        install_scripts.write_script(self, script_name, contents,
+                                     mode="t", *ignored)
 
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
 
 setup(
     name="carbonate",
@@ -22,19 +24,19 @@ setup(
     author="Scott Sanders",
     author_email="scott@jssjr.com",
     description=("Tools for managing federated carbon clusters."),
-    license = "MIT",
-    keywords = "graphite carbon",
-    url = "https://github.com/jssjr/carbonate",
-    include_package_data = True,
+    license="MIT",
+    keywords="graphite carbon",
+    url="https://github.com/jssjr/carbonate",
+    include_package_data=True,
     packages=find_packages(),
-    long_description = read('README.md'),
+    long_description=read('README.md'),
     long_description_content_type='text/markdown',
-    install_requires = [
+    install_requires=[
       "carbon",
       "whisper",
     ],
     cmdclass={'install_scripts': my_install_scripts},
-    entry_points = {
+    entry_points={
         'console_scripts': [
             'carbon-lookup = carbonate.cli:carbon_lookup',
             'carbon-sync = carbonate.cli:carbon_sync',
@@ -45,6 +47,12 @@ setup(
             'carbon-stale = carbonate.cli:carbon_stale',
             'whisper-fill = carbonate.cli:whisper_fill',
             'whisper-aggregate = carbonate.cli:whisper_aggregate'
-            ]
-        }
-    )
+        ]
+    },
+    classifiers=[
+        'License :: OSI Approved :: MIT License'
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+    ]
+)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@ nose
 mock
 coverage
 nosexcover
-flake8
+flake8<3.7
 mccabe==0.6.1
 tox
 pep8

--- a/tests/test_fill.py
+++ b/tests/test_fill.py
@@ -140,7 +140,7 @@ class FillTest(unittest.TestCase):
         except (IOError, OSError):
             pass
 
-        complete = range(1, 21)
+        complete = list(range(1, 21))
         seconds_per_point = 1
         seconds_per_point_l2 = seconds_per_point * 4
         points_number = len(complete)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -52,7 +52,7 @@ class SyncTest(unittest.TestCase):
         heal_metric(self.db, testdb, overwrite=True)
 
         final_data = whisper.fetch(testdb, 0)
-        self.assertEqual(final_data[1], range(1,21))
+        self.assertEqual(final_data[1], list(range(1,21)))
 
 
     def test_heal_empty(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py27-pre0_9_10,lint
+envlist = py27,py27-pre0_9_10,lint,py3
 
 [testenv]
 install_command = pip install --install-option='--install-scripts={envbindir}' --install-option='--install-lib={envsitepackagesdir}' --install-option='--install-data={envdir}/lib/graphite' -r{toxinidir}/requirements.txt -r{toxinidir}/tests/requirements.txt --pre {opts} {packages}


### PR DESCRIPTION
A distinguishing feature of rsync as compared to scp/ftp/etc is the rsync algorithm (https://www.samba.org/~tridge/phd_thesis.pdf), which finds a near-optimal transfer block size for comparisons to avoid transmitting unchanged data within files which are partly changed.

In usage of rsync where the rsync destination is not the final destination(e.g. as used in carbonate w/ a staging dir), the default options do not allow it to find the base files for this comparison. rsync provides the --{link,copy,compare}-dest options for this purpose, but carbonate does not currently make use of them. This is significant to me because I'm using carbon-sync for replicating metrics between cloud providers and around the world, in some cases where bandwidth is constrained.

Relative to --copy-dest, --compare-dest and --link-dest would reduce some disk ops on the receiver when files match exactly, but I discounted those options for these reasons:
* only stale whisper files should generally match exactly (i.e. depends on cache size), seems like kind of a corner-case
* --link-dest assumes staging and storage_dir on the same FS
* --compare-dest does not create destination files, leaving that up the the user during post-processing. This would be fine except that carbon-sync will either report a noisy error or be modified to ignore that.

As expected, in testing carbon-sync with --copy-dest with mostly-matching whisper files I saw huge improvements in rsync time and in bandwidth usage (testing within one VPC <50% time and <5% bandwidth). Obviously this doesn't help when the files mostly *do not* match, and it potentially creates more I/O on the receiver because now rsync must read the whisper files in addition to carbon-sync. That seems like a great tradeoff to me, how does graphite-project feel about it?