### PR TITLE
fixes python3 TypeError

### DIFF
--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -31,7 +31,7 @@ def sync_from_remote(sync_file, remote, staging, rsync_options):
                                 stderr=subprocess.STDOUT)
 
         for l in iter(proc.stdout.readline, b''):
-            sys.stdout.write(l)
+            sys.stdout.write(l.decode("utf-8"))
             sys.stdout.flush()
     except subprocess.CalledProcessError as e:
         logging.warn("Failed to sync from %s! %s" % (remote, e))
@@ -118,7 +118,7 @@ def heal_metric(source, dest, start_time=0, end_time=None, overwrite=False,
 def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
               remote_ip, dirty, lock_writes=False, overwrite=False):
     staging_dir = mkdtemp(prefix=remote_ip)
-    sync_file = NamedTemporaryFile(mode='w', delete=False)
+    sync_file = NamedTemporaryFile(delete=False)
 
     metrics_to_heal = []
 
@@ -129,7 +129,7 @@ def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
         local_file = "%s/%s" % (local_storage, metric)
         metrics_to_heal.append((staging_file, local_file))
 
-    sync_file.write("\n".join(metrics_to_sync))
+    sync_file.write(("\n".join(metrics_to_sync)).encode())
     sync_file.flush()
 
     rsync_start = time()


### PR DESCRIPTION
With Python 3.6.8 and carbonate release 1.1.6 had the following issue

~~~bash
ssh -q $REMOTE_IP -- carbon-list -d /var/lib/carbon |
carbon-sieve -n $REMOTE_IP |
carbon-sync -s $REMOTE_IP -d /var/lib/carbon --source-storage-dir /var/lib/carbon

* Running batch 1-10000
Traceback (most recent call last):
  File "/opt/graphite/bin/carbon-sync", line 12, in <module>
    load_entry_point('carbonate==1.1.6', 'console_scripts', 'carbon-sync')()
  File "/opt/graphite/lib/python3.6/site-packages/carbonate/cli.py", line 236, in carbon_sync
    overwrite=args.overwrite)
  File "/opt/graphite/lib/python3.6/site-packages/carbonate/sync.py", line 132, in run_batch
    sync_file.write("\n".join(metrics_to_sync))
  File "/opt/graphite/lib64/python3.6/tempfile.py", line 485, in func_wrapper
    return func(*args, **kwargs)
TypeError: a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "/opt/graphite/bin/carbon-sieve", line 12, in <module>
    load_entry_point('carbonate==1.1.6', 'console_scripts', 'carbon-sieve')()
  File "/opt/graphite/lib/python3.6/site-packages/carbonate/cli.py", line 133, in carbon_sieve
    print(metric.strip())
BrokenPipeError: [Errno 32] Broken pipe
~~~


and with the master branch:
~~~
ssh -q $REMOTE_IP -- carbon-list -d /var/lib/carbon |
carbon-sieve -n $REMOTE_IP |
carbon-sync -s $REMOTE_IP -d /var/lib/carbon --source-storage-dir /var/lib/carbon

* Running batch 1-1000
  - Rsyncing metrics
Traceback (most recent call last):
  File "/opt/graphite/bin/carbon-sync", line 12, in <module>
    load_entry_point('carbonate==1.1.6', 'console_scripts', 'carbon-sync')()
  File "/opt/graphite/lib/python3.6/site-packages/carbonate/cli.py", line 236, in carbon_sync
    overwrite=args.overwrite)
  File "/opt/graphite/lib/python3.6/site-packages/carbonate/sync.py", line 137, in run_batch
    sync_from_remote(sync_file, remote, staging, rsync_options)
  File "/opt/graphite/lib/python3.6/site-packages/carbonate/sync.py", line 34, in sync_from_remote
    sys.stdout.write(l)
TypeError: write() argument must be str, not bytes
Traceback (most recent call last):
  File "/opt/graphite/bin/carbon-sieve", line 12, in <module>
    load_entry_point('carbonate==1.1.6', 'console_scripts', 'carbon-sieve')()
  File "/opt/graphite/lib/python3.6/site-packages/carbonate/cli.py", line 133, in carbon_sieve
    print(metric.strip())
BrokenPipeError: [Errno 32] Broken pipe
~~~

The PR fixed it for me, tested on python 3.6.8 only.