### PR TITLE
Handle transient network failures and support custom staging dir path

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ usage: carbon-sync [-h] [-c CONFIG_FILE] [-C CLUSTER] [-f METRICS_FILE] -s
                    SOURCE_NODE [-d STORAGE_DIR] [-b BATCH_SIZE]
                    [--source-storage-dir SOURCE_STORAGE_DIR]
                    [--rsync-options RSYNC_OPTIONS] [--rsync-disable-copy-dest]
-                   [--dirty] [-l] [-o]
+                   [--tmpdir TMP_STAGING_DIR] [--rsync-max-retries MAX_RETRIES]
+                   [--rsync-retries-interval SECONDS] [--dirty] [-l] [-o]
 
 Sync local metrics using remote nodes in the cluster
 
@@ -176,6 +177,22 @@ optional arguments:
   --rsync-disable-copy-dest
                         Avoid --copy-dest, transfer all whisper data between
                         nodes. (default: False)
+  --rsync-max-retries RETRIES
+                        Number of times rsync will attempt to copy each batch
+                        of metrics before moving on. If all retry attempts are
+                        unsuccessful, carbon-sync will write a file containing
+                        the name of each metric in the failed batch so they can
+                        be easily retried at a later time. (Default: 3)
+  --rsync-retries-interval SECONDS
+                        How long to wait in between each rsync retry attempt
+                        (see --rsync-max-retries). (default: 5)
+  -t TMP_STAGING_DIR, --tmpdir TMP_STAGING_DIR
+                        Specify an alternate location in which the temporary
+                        rsync staging dirs will be created. This can be useful
+                        for large syncs where the default location (as chosen
+                        by mkdtemp) resides on a filesystem that's too small
+                        to store all the metrics being copied from the remote
+                        host.
   --dirty               If set, don't clean temporary rsync directory
                         (default: False)
   -l, --lock            Lock whisper files during filling (default: False)

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -213,6 +213,17 @@ def carbon_sync():
         default=None,
         help='Specify where temporary rsync directories will be created')
 
+    parser.add_argument(
+        '--rsync-max-retries',
+        type=int,
+        default=3,
+        help='Maximum number of rsync attempts for each batch of metrics')
+
+    parser.add_argument(
+        '--rsync-retries-interval',
+        default=5,
+        help='How long to wait (in seconds) between rsync retry attempts')
+
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
@@ -250,7 +261,9 @@ def carbon_sync():
             run_batch(metrics_to_sync, remote,
                       args.storage_dir, rsync_options,
                       remote_ip, args.dirty, lock_writes=whisper_lock_writes,
-                      overwrite=args.overwrite, tmpdir=args.tmpdir)
+                      overwrite=args.overwrite, tmpdir=args.tmpdir,
+                      rsync_max_retries=args.rsync_max_retries,
+                      rsync_retries_interval=args.rsync_retries_interval)
             metrics_to_sync = []
 
     if len(metrics_to_sync) > 0:
@@ -258,7 +271,10 @@ def carbon_sync():
               % (total_metrics-len(metrics_to_sync)+1, total_metrics))
         run_batch(metrics_to_sync, remote,
                   args.storage_dir, rsync_options,
-                  remote_ip, args.dirty, lock_writes=whisper_lock_writes)
+                  remote_ip, args.dirty, lock_writes=whisper_lock_writes,
+                  overwrite=args.overwrite, tmpdir=args.tmpdir,
+                  rsync_max_retries=args.rsync_max_retries,
+                  rsync_retries_interval=args.rsync_retries_interval)
 
     elapsed = (time() - start)
 

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -208,6 +208,11 @@ def carbon_sync():
         action='store_true',
         help='Write all non nullpoints from src to dst')
 
+    parser.add_argument(
+        '-t', '--tmpdir',
+        default=None,
+        help='Specify where temporary rsync directories will be created')
+
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
@@ -245,7 +250,7 @@ def carbon_sync():
             run_batch(metrics_to_sync, remote,
                       args.storage_dir, rsync_options,
                       remote_ip, args.dirty, lock_writes=whisper_lock_writes,
-                      overwrite=args.overwrite)
+                      overwrite=args.overwrite, tmpdir=args.tmpdir)
             metrics_to_sync = []
 
     if len(metrics_to_sync) > 0:

--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -145,9 +145,9 @@ def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
 
         sync_tries = 0
         sync_success = False
+        rsync_start = time.time()
         while not sync_success and sync_tries < rsync_max_retries:
             sync_tries += 1
-            rsync_start = time.time()
             sync_success = sync_from_remote(sync_file, remote, staging_dir,
                                             rsync_options)
             if not sync_success:

--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -39,7 +39,7 @@ def sync_from_remote(sync_file, remote, staging, rsync_options):
 
     if proc.returncode != 0:
         logging.warn("Failed to sync from %s! rsync rc=%d",
-                        remote, proc.returncode)
+                     remote, proc.returncode)
         return False
     return True
 
@@ -129,7 +129,7 @@ def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
         staging_dir = mkdtemp(prefix=remote_ip, dir=tmpdir)
     except OSError as e:
         logging.error('Failed to create rsync staging dir %s: %s' %
-            (e.filename, e.strerror))
+                      (e.filename, e.strerror))
     else:
         sync_file = NamedTemporaryFile(delete=False, dir=tmpdir)
 

--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -3,7 +3,7 @@ import sys
 import logging
 import shutil
 import subprocess
-from time import time
+import time
 from datetime import timedelta
 from tempfile import mkdtemp, NamedTemporaryFile
 from shutil import rmtree
@@ -14,31 +14,38 @@ from .fill import fill_archives
 
 def sync_from_remote(sync_file, remote, staging, rsync_options):
     try:
-        try:
-            os.makedirs(os.path.dirname(staging))
-        except OSError:
-            pass
+        os.makedirs(os.path.dirname(staging))
+    except OSError:
+        pass
 
-        cmd = " ".join(['rsync', rsync_options, '--files-from',
-                        sync_file.name, remote, staging
-                        ])
+    cmd = " ".join(['rsync', rsync_options, '--files-from',
+                    sync_file.name, remote, staging + '/'
+                    ])
 
-        print("  - Rsyncing metrics")
+    print("  - Rsyncing metrics: %s" % cmd)
 
-        proc = subprocess.Popen(cmd,
-                                shell=True,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.STDOUT)
+    proc = subprocess.Popen(cmd,
+                            shell=True,
+                            universal_newlines=True,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT)
 
-        for line in iter(proc.stdout.readline, b''):
-            sys.stdout.write(line.decode("utf-8"))
-            sys.stdout.flush()
-    except subprocess.CalledProcessError as e:
-        logging.warn("Failed to sync from %s! %s" % (remote, e))
+    for line in iter(proc.stdout.readline, b''):
+        sys.stdout.write(line.decode("utf-8"))
+        sys.stdout.flush()
+
+    proc.communicate()
+    print("    rc: %d" % proc.returncode)
+
+    if proc.returncode != 0:
+        logging.warn("Failed to sync from %s! rsync rc=%d",
+                        remote, proc.returncode)
+        return False
+    return True
 
 
 def sync_batch(metrics_to_heal, lock_writes=False, overwrite=False):
-    batch_start = time()
+    batch_start = time.time()
     sync_count = 0
     sync_total = len(metrics_to_heal)
     sync_avg = 0.1
@@ -47,7 +54,7 @@ def sync_batch(metrics_to_heal, lock_writes=False, overwrite=False):
 
     for (staging, local) in metrics_to_heal:
         sync_count += 1
-        sync_start = time()
+        sync_start = time.time()
         sync_percent = float(sync_count) / sync_total * 100
         status_line = "  - Syncing %d of %d metrics. " \
                       "Avg: %fs  Time Left: %ss (%d%%)" \
@@ -61,19 +68,19 @@ def sync_batch(metrics_to_heal, lock_writes=False, overwrite=False):
                     overwrite=overwrite,
                     lock_writes=lock_writes)
 
-        sync_elapsed += time() - sync_start
+        sync_elapsed += time.time() - sync_start
         sync_avg = sync_elapsed / sync_count
         sync_remain_s = sync_avg * (sync_total - sync_count)
         sync_remain = str(timedelta(seconds=sync_remain_s))
 
-    batch_elapsed = time() - batch_start
+    batch_elapsed = time.time() - batch_start
     return batch_elapsed
 
 
 def heal_metric(source, dest, start_time=0, end_time=None, overwrite=False,
                 lock_writes=False):
     if end_time is None:
-        end_time = time()
+        end_time = time.time()
     try:
         with open(dest):
             try:
@@ -116,42 +123,61 @@ def heal_metric(source, dest, start_time=0, end_time=None, overwrite=False,
 
 
 def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
-              remote_ip, dirty, lock_writes=False, overwrite=False):
-    staging_dir = mkdtemp(prefix=remote_ip)
-    sync_file = NamedTemporaryFile(delete=False)
-
-    metrics_to_heal = []
-
-    staging = "%s/" % (staging_dir)
-
-    for metric in metrics_to_sync:
-        staging_file = "%s/%s" % (staging_dir, metric)
-        local_file = "%s/%s" % (local_storage, metric)
-        metrics_to_heal.append((staging_file, local_file))
-
-    sync_file.write(("\n".join(metrics_to_sync)).encode())
-    sync_file.flush()
-
-    rsync_start = time()
-
-    sync_from_remote(sync_file, remote, staging, rsync_options)
-
-    rsync_elapsed = (time() - rsync_start)
-
-    merge_elapsed = sync_batch(metrics_to_heal, lock_writes=lock_writes,
-                               overwrite=overwrite)
-
-    total_time = rsync_elapsed + merge_elapsed
-
-    print("    --------------------------------------")
-    print("    Rsync time: %ss" % rsync_elapsed)
-    print("    Merge time: %ss" % merge_elapsed)
-    print("    Total time: %ss" % total_time)
-
-    # Cleanup
-    if dirty:
-        print("    dirty mode: left temporary directory %s" % staging_dir)
+              remote_ip, dirty, lock_writes=False, overwrite=False,
+              tmpdir=None):
+    try:
+        staging_dir = mkdtemp(prefix=remote_ip, dir=tmpdir)
+    except OSError as e:
+        logging.error('Failed to create rsync staging dir %s: %s' %
+            (e.filename, e.strerror))
     else:
-        rmtree(staging_dir)
+        sync_file = NamedTemporaryFile(delete=False, dir=tmpdir)
 
-    os.unlink(sync_file.name)
+        metrics_to_heal = []
+
+        for metric in metrics_to_sync:
+            staging_file = "%s/%s" % (staging_dir, metric)
+            local_file = "%s/%s" % (local_storage, metric)
+            metrics_to_heal.append((staging_file, local_file))
+
+        sync_file.write(("\n".join(metrics_to_sync)).encode())
+        sync_file.flush()
+
+        sync_tries = 0
+        sync_success = False
+        while not sync_success and sync_tries < 3:
+            sync_tries += 1
+            rsync_start = time.time()
+            sync_success = sync_from_remote(sync_file, remote, staging_dir,
+                                            rsync_options)
+            if not sync_success:
+                time.sleep(5)
+
+        rsync_elapsed = (time.time() - rsync_start)
+
+        if sync_success:
+            merge_elapsed = sync_batch(metrics_to_heal,
+                                       lock_writes=lock_writes,
+                                       overwrite=overwrite)
+        else:
+            merge_elapsed = 0.0
+            with NamedTemporaryFile(delete=False,
+                                    dir=tmpdir,
+                                    suffix='.failed') as f:
+                f.write(("\n".join(metrics_to_sync)).encode())
+                print("    Rsync failed; metric names saved to %s" % f.name)
+
+        total_time = rsync_elapsed + merge_elapsed
+
+        print("    --------------------------------------")
+        print("    Rsync time: %ss" % rsync_elapsed)
+        print("    Merge time: %ss" % merge_elapsed)
+        print("    Total time: %ss" % total_time)
+
+        # Cleanup
+        if dirty:
+            print("    dirty mode: left temporary directory %s" % staging_dir)
+        else:
+            rmtree(staging_dir)
+
+        os.unlink(sync_file.name)

--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -124,7 +124,7 @@ def heal_metric(source, dest, start_time=0, end_time=None, overwrite=False,
 
 def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
               remote_ip, dirty, lock_writes=False, overwrite=False,
-              tmpdir=None, rsync_max_retries, rsync_retries_interval):
+              tmpdir=None, rsync_max_retries=3, rsync_retries_interval=5):
     try:
         staging_dir = mkdtemp(prefix=remote_ip, dir=tmpdir)
     except OSError as e:

--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -124,7 +124,7 @@ def heal_metric(source, dest, start_time=0, end_time=None, overwrite=False,
 
 def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
               remote_ip, dirty, lock_writes=False, overwrite=False,
-              tmpdir=None):
+              tmpdir=None, rsync_max_retries, rsync_retries_interval):
     try:
         staging_dir = mkdtemp(prefix=remote_ip, dir=tmpdir)
     except OSError as e:
@@ -145,13 +145,13 @@ def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
 
         sync_tries = 0
         sync_success = False
-        while not sync_success and sync_tries < 3:
+        while not sync_success and sync_tries < rsync_max_retries:
             sync_tries += 1
             rsync_start = time.time()
             sync_success = sync_from_remote(sync_file, remote, staging_dir,
                                             rsync_options)
             if not sync_success:
-                time.sleep(5)
+                time.sleep(rsync_retries_interval)
 
         rsync_elapsed = (time.time() - rsync_start)
 


### PR DESCRIPTION
This PR makes two improvements:

1. If a transient connectivity issue occurs while rsyncing a batch from the remote host, sync.py will wait for 5 seconds and then retry a sync of that batch. If, after 3 such attempts, syncing has not succeeded, the metrics in that failed batch are saved to a file so that they can be easily retried by the user at a later time.

2. Adds a second command-line option (`-t` or `--tmpdir`) which allows the user to specify where the temporary rsync staging dirs will be created. This can be useful for very large syncs where the filesystem containing `/tmp` (or wherever `mkdtemp` would create it on the user's OS) isn't big enough to store all the synced metrics.