### PR TITLE
Resolves issue #127 - python3 safe stdout handling

### DIFF
--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -30,8 +30,8 @@ def sync_from_remote(sync_file, remote, staging, rsync_options):
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
 
-    for line in iter(proc.stdout.readline, b''):
-        sys.stdout.write(line.decode("utf-8"))
+    for line in iter(proc.stdout.readline, ''):
+        sys.stdout.write(line)
         sys.stdout.flush()
 
     proc.communicate()


### PR DESCRIPTION
* modifies `sync.py`
  - makes `iter` sentinel a regular `str` instead of a `bytes`
  - removes the call to `str.decode` which is invalid on python3

The rsync process is forked with `subprocess.Popen` with `universal_newlines=True` so the [stream from stdout will be of `str` type](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.stdout). Instances of `str` do not have a `decode` method in python3 and the decode method being called in python2 was effectively a noop. This MR should result in uniform behavior in both python2 and 3.