### PR TITLE
Fix broken sync script for rsync v3.1.2

### DIFF
--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -140,7 +140,7 @@ def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
             local_file = "%s/%s" % (local_storage, metric)
             metrics_to_heal.append((staging_file, local_file))
 
-        sync_file.write(("\n".join(metrics_to_sync)).encode())
+        sync_file.write(("\n".join(metrics_to_sync) + "\n").encode())
         sync_file.flush()
 
         sync_tries = 0


### PR DESCRIPTION
rsync v3.1.2 expects every line in the `--from-file` to have a newline. Otherwise, it throws an error.  This cancels the entire sync.

```
* Running batch 2401-2700
  - Rsyncing metrics: rsync -azpS --copy-dest="/u2/carbon" --files-from /tmp/tmp1heicu_k carbon@1x.2x.3x.9x:/u2/carbon/ /tmp/1
0.20.36.96dz00hbdq/
ERROR: rejecting unrequested file-list name: whisper/diamond/xxxxxxx/xxxxxx/xxxxxx/memory/SwapFree.wsp
rsync error: protocol incompatibility (code 2) at flist.c(911) [Receiver=3.1.2]
WARNING:root:Failed to sync from carbon@1x.2x.3x.9x:/u2/carbon/! rsync rc=2
```